### PR TITLE
ツイートの編集機能の実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -12,6 +12,7 @@ class TweetsController < ApplicationController
 
   def create
     Tweet.create(text: tweet_params[:text], user_id: current_user.id)
+    redirect_to root_path, notice: '投稿が完了しました'
   end
 
   def destroy
@@ -22,6 +23,7 @@ class TweetsController < ApplicationController
   def update
     tweet = Tweet.find(params[:id])
     tweet.update(tweet_params) if tweet.user_id == current_user.id
+    redirect_to root_path, notice: '編集が完了しました'
   end
 
   def edit
@@ -34,7 +36,7 @@ class TweetsController < ApplicationController
 
   private
   def tweet_params
-    params.permit(:text)
+    params.permit(:name, :text)
   end
 
   # ユーザーがサインインしてない時、indexアクションを実行する

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="row" style="padding-top: 50px;">
+<div class="col s12 m6 offset-m3">
+  <h1>
+    Editing tweet
+  </h1>
+  <%= form_with url: tweet_path, method: :patch, lacal: true do |form| %>
+    <div class="field">
+      <label for="tweet_text">Text</label>
+      <%= form.text_area :text %>
+    </div>      
+    <div class="actions">
+      <%= form.submit :commit %>
+    </div>
+  <% end %>
+</div>
+</div>


### PR DESCRIPTION
# What
ツイートの編集機能を実装した。
自分のツイートを編集したいときに編集できるようにした。
ログインしていない人には編集ボタンを表示できないようにしている。

# Why
ツイートの編集機能は間違ったツイートなどを修正する際に必要なため。
自分以外の人が編集できないようにすることによって、意図しない修正を避ける。